### PR TITLE
Don't enforce signingConfig if release.properties doesn't exist

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -65,16 +65,18 @@ android {
 
     signingConfigs {
         release {
-            def Properties releaseProps = new Properties()
-            releaseProps.load(new FileInputStream(rootProject.file('release.properties')))
+            if (rootProject.file('release.properties').exists()) {
+                def Properties releaseProps = new Properties()
+                releaseProps.load(new FileInputStream(rootProject.file('release.properties')))
 
-            def Properties ksProps = new Properties()
-            ksProps.load(new FileInputStream(new File((String) releaseProps['signing.config'])))
-            storeFile file(ksProps['keystore'])
-            keyAlias ksProps['alias']
-            storePassword ksProps['storePass']
-            keyPassword ksProps['pass']
-            storeType ksProps['storeType']
+                def Properties ksProps = new Properties()
+                ksProps.load(new FileInputStream(new File((String) releaseProps['signing.config'])))
+                storeFile file(ksProps['keystore'])
+                keyAlias ksProps['alias']
+                storePassword ksProps['storePass']
+                keyPassword ksProps['pass']
+                storeType ksProps['storeType']
+            }
         }
     }
 


### PR DESCRIPTION
When building a community build it will error out because it doesn't find the release signing properties file.

In android-studio it's even worse as when checking from GitHub it won't even open the project because of it.

Add an exists check before importing them to the gradle configuration file.