### PR TITLE
Add a debug suffix for community building

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -81,6 +81,7 @@ android {
     buildTypes {
         debug {
             debuggable true
+            applicationIdSuffix ".debug"
         }
         release {
             debuggable false


### PR DESCRIPTION
Include a ".debug" suffix after the appId so community builds can coexist with the Play Store release one on development devices.