### PR TITLE
Correct text hint when reverting/restoring a change

### DIFF
--- a/app/src/main/java/com/ruesga/rview/fragments/ChangeDetailsFragment.java
+++ b/app/src/main/java/com/ruesga/rview/fragments/ChangeDetailsFragment.java
@@ -1514,7 +1514,7 @@ public class ChangeDetailsFragment extends Fragment {
 
                 case R.id.abandon:
                     action = getString(R.string.change_action_abandon);
-                    hint = getString(R.string.actions_message_hint);
+                    hint = getString(R.string.change_details_review_hint);
                     performShowRequestMessageDialog(v, action, action, hint, true,
                             newValue -> {
                                 mActionLoader.clear();
@@ -1525,7 +1525,7 @@ public class ChangeDetailsFragment extends Fragment {
 
                 case R.id.restore:
                     action = getString(R.string.change_action_restore);
-                    hint = getString(R.string.actions_message_hint);
+                    hint = getString(R.string.change_details_review_hint);
                     performShowRequestMessageDialog(v, action, action, hint, true,
                             newValue -> {
                                 mActionLoader.clear();


### PR DESCRIPTION
Currently, when reverting or restoring a change, the EditText
in the dialog hints to type a "Commit Message".

However, there is no commit message to be entered. Instead,
a comment is entered, just like a normal comment on any change.

Hence, correct the text hint to display "Comment on this change".