### PR TITLE
Gradle: Improved dependencies resolution & run dex in-process

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+android.enableImprovedDependenciesResolution=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,2 @@
 android.enableImprovedDependenciesResolution=true
+org.gradle.jvmargs=-Xmx1536M


### PR DESCRIPTION
This makes dependencies resolve during Gradle execution time instead of
configuration time, speeding up running simple / generic tasks that do
not need any dependencies.

Also, increase the Gradle daemon's heap size to be able to run dex in-process.