### PR TITLE
Support status draft

### DIFF
--- a/gerrit/src/main/java/com/ruesga/rview/gerrit/filter/StatusType.java
+++ b/gerrit/src/main/java/com/ruesga/rview/gerrit/filter/StatusType.java
@@ -16,5 +16,5 @@
 package com.ruesga.rview.gerrit.filter;
 
 public enum StatusType {
-    OPEN, PENDING, REVIEWED, CLOSED, MERGED, ABANDONED
+    OPEN, PENDING, REVIEWED, CLOSED, MERGED, ABANDONED, DRAFT
 }

--- a/gerrit/src/main/java/com/ruesga/rview/gerrit/filter/StatusType.java
+++ b/gerrit/src/main/java/com/ruesga/rview/gerrit/filter/StatusType.java
@@ -15,6 +15,8 @@
  */
 package com.ruesga.rview.gerrit.filter;
 
+import com.ruesga.rview.gerrit.annotations.Until;
+
 public enum StatusType {
-    OPEN, PENDING, REVIEWED, CLOSED, MERGED, ABANDONED, DRAFT
+    OPEN, PENDING, REVIEWED, CLOSED, MERGED, ABANDONED, @Until(2.15) DRAFT
 }


### PR DESCRIPTION
Gerrit with version <2.15 has draft changes. This adds support in the query engine for the draft status.