### PR TITLE
Handle junctions as first query parameter

### DIFF
--- a/gerrit/src/main/java/com/ruesga/rview/gerrit/filter/ChangeQuery.java
+++ b/gerrit/src/main/java/com/ruesga/rview/gerrit/filter/ChangeQuery.java
@@ -421,7 +421,7 @@ public class ChangeQuery extends ComplexQuery<ChangeQuery> {
                         case QueryLexer.OR:
                             ChangeQuery q = toChangeQuery(tree.getChild(0));
                             if (query.queries().isEmpty()) {
-                                query = q;
+                                query.add("(" + q + ")");
                             } else if (childType == QueryLexer.AND) {
                                 query.and(q);
                             } else {

--- a/gerrit/src/test/java/com/ruesga/rview/gerrit/filter/ChangeQueryTest.java
+++ b/gerrit/src/test/java/com/ruesga/rview/gerrit/filter/ChangeQueryTest.java
@@ -97,17 +97,21 @@ public class ChangeQueryTest {
                                 .and(new ChangeQuery().branch("test2"))));
 
 
-        testParseQuery("(is:open label:Verified=+1 -age:1month) AND NOT (is:open reviewerin:Tuleap-Integrators -age:1month label:Verified=+1 -is:draft)",
+        ChangeQuery complexQuery = new ChangeQuery();
+        complexQuery.add("(" +
                 new ChangeQuery().is(IsType.OPEN)
                         .and(new ChangeQuery().label("Verified", 1))
                         .and(new ChangeQuery().negate(new ChangeQuery().age(TimeUnit.MONTHS, 1)))
-                        .and(new ChangeQuery().negate(
-                                new ChangeQuery().is(IsType.OPEN)
-                                        .and(new ChangeQuery().reviewerIn("Tuleap-Integrators"))
-                                        .and(new ChangeQuery().negate(new ChangeQuery().age(TimeUnit.MONTHS, 1)))
-                                        .and(new ChangeQuery().label("Verified", 1))
-                                        .and(new ChangeQuery().negate(new ChangeQuery().is(IsType.DRAFT)))
-                        )));
+                + ")");
+        complexQuery.and(new ChangeQuery().negate(
+                new ChangeQuery().is(IsType.OPEN)
+                        .and(new ChangeQuery().reviewerIn("Tuleap-Integrators"))
+                        .and(new ChangeQuery().negate(new ChangeQuery().age(TimeUnit.MONTHS, 1)))
+                        .and(new ChangeQuery().label("Verified", 1))
+                        .and(new ChangeQuery().negate(new ChangeQuery().is(IsType.DRAFT)))
+        ));
+        testParseQuery("(is:open label:Verified=+1 -age:1month) AND NOT (is:open reviewerin:Tuleap-Integrators -age:1month label:Verified=+1 -is:draft)",
+                complexQuery);
     }
 
     private void testParseQuery(String expression, ChangeQuery expectedResult) {


### PR DESCRIPTION
Add parenthesis around junction if it is the first parameter of a query

A dashboard query defined as: `(reviewer:self OR owner:self) status:merged -age:1w`
is right now translated as `reviewer:self OR owner:self AND status:merged AND -(age:1w)`.

If the first element in the tree is AND/OR it also needs to be set between parenthesis.