### PR TITLE
Accept user installed CA certificates for https connections

### DIFF
--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -13,7 +13,15 @@
      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
      See the License for the specific language governing permissions and
      limitations under the License.
+
+     This makes the app accept manually added CAs trusted by the user and also allows unencrypted HTTP Connections
+     https://developer.android.com/training/articles/security-config
  -->
 <network-security-config>
-    <base-config cleartextTrafficPermitted="true" />
+    <base-config cleartextTrafficPermitted="true">
+        <trust-anchors>
+            <certificates src="system" />
+            <certificates src="user" />
+        </trust-anchors>
+    </base-config>
 </network-security-config>

--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ allprojects {
             maven { url 'https://maven.fabric.io/public' }
         }
         dependencies {
-            classpath 'com.android.tools.build:gradle:3.5.0-beta01'
+            classpath 'com.android.tools.build:gradle:3.5.0'
             classpath 'com.getkeepsafe.dexcount:dexcount-gradle-plugin:0.8.6'
             // https://s3.amazonaws.com/fabric-artifacts/public/io/fabric/tools/gradle/maven-metadata.xml
             classpath 'io.fabric.tools:gradle:1.28.1'


### PR DESCRIPTION
In recent Android Versions apps no longer trust certificates installed by the user unless the app explicitly declares to trust the "user" truststore as well.
https://developer.android.com/training/articles/security-config#base-config

This change makes the app accept trusted CA certificates (manually installed by the user) so users with a gerrit instance where the https Certificate ist signed by a custom/company CA no longer have to tick "Trust all server certificates" when the CA certificate is installed as a trusted CA.