### PR TITLE
Make debug builds able to coexist to the official app

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -100,6 +100,8 @@ android {
         debug {
             debuggable true
 
+            applicationIdSuffix ".debug"
+
             ext.enableCrashlytics = false
 
             minifyEnabled true

--- a/app/src/debug/res/values/strings.xml
+++ b/app/src/debug/res/values/strings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright (C) 2016 Jorge Ruesga
+
+     Licensed under the Apache License, ServerVersion 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+ -->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <!-- App name -->
+    <string name="app_name" translatable="false">Rview (debug)</string>
+</resources>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,14 +19,14 @@
     package="com.ruesga.rview">
 
     <permission
-        android:name="com.ruesga.rview.permissions.PRIVATE_ACCESS"
+        android:name="${applicationId}.permissions.PRIVATE_ACCESS"
         android:protectionLevel="signature"/>
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-    <uses-permission android:name="com.ruesga.rview.permissions.PRIVATE_ACCESS" />
+    <uses-permission android:name="${applicationId}.permissions.PRIVATE_ACCESS" />
 
     <application
         android:name=".RviewApplication"
@@ -67,9 +67,9 @@
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
-                <data android:scheme="com.ruesga.rview" android:host="change" />
-                <data android:scheme="com.ruesga.rview" android:host="commit" />
-                <data android:scheme="com.ruesga.rview" android:host="changeid" />
+                <data android:scheme="${applicationId}" android:host="change" />
+                <data android:scheme="${applicationId}" android:host="commit" />
+                <data android:scheme="${applicationId}" android:host="changeid" />
             </intent-filter>
         </activity-alias>
 
@@ -156,7 +156,7 @@
 
         <provider
             android:name=".providers.RviewProvider"
-            android:authorities="com.ruesga.rview"
+            android:authorities="${applicationId}"
             android:exported="false"/>
 
         <service
@@ -186,35 +186,35 @@
 
         <receiver
             android:name=".receivers.NotificationReceiver"
-            android:permission="com.ruesga.rview.permissions.PRIVATE_ACCESS">
+            android:permission="${applicationId}.permissions.PRIVATE_ACCESS">
             <intent-filter>
                 <action android:name="android.intent.action.LOCALE_CHANGED" />
-                <action android:name="com.ruesga.rview.action.NOTIFICATION_DISMISSED" />
-                <action android:name="com.ruesga.rview.action.NOTIFICATION_REPLY" />
+                <action android:name="${applicationId}.action.NOTIFICATION_DISMISSED" />
+                <action android:name="${applicationId}.action.NOTIFICATION_REPLY" />
             </intent-filter>
         </receiver>
 
         <receiver
             android:name=".receivers.CacheCleanerReceiver"
-            android:permission="com.ruesga.rview.permissions.PRIVATE_ACCESS">
+            android:permission="${applicationId}.permissions.PRIVATE_ACCESS">
             <intent-filter>
-                <action android:name="com.ruesga.rview.action.CLEAN_CACHE" />
+                <action android:name="${applicationId}.action.CLEAN_CACHE" />
             </intent-filter>
         </receiver>
 
         <provider
             android:name="androidx.core.content.FileProvider"
-            android:authorities="com.ruesga.rview.content"
+            android:authorities="${applicationId}.content"
             android:grantUriPermissions="true"
             android:exported="false"
-            android:writePermission="com.ruesga.rview.permissions.PRIVATE_ACCESS">
+            android:writePermission="${applicationId}.permissions.PRIVATE_ACCESS">
             <meta-data
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/content_paths" />
         </provider>
 
         <!-- Disable auto-manage gson services -->
-        <provider android:authorities="com.ruesga.rview.firebaseinitprovider"
+        <provider android:authorities="${applicationId}.firebaseinitprovider"
             android:name="com.google.firebase.provider.FirebaseInitProvider"
             android:exported="false"
             tools:node="remove"/>

--- a/app/src/main/java/com/ruesga/rview/providers/NotificationEntity.java
+++ b/app/src/main/java/com/ruesga/rview/providers/NotificationEntity.java
@@ -27,13 +27,12 @@ import android.provider.BaseColumns;
 import android.text.TextUtils;
 import android.text.format.DateUtils;
 
+import com.ruesga.rview.BuildConfig;
 import com.ruesga.rview.misc.SerializationManager;
 import com.ruesga.rview.model.Notification;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import static com.ruesga.rview.providers.RviewProvider.AUTHORITY;
 
 public class NotificationEntity implements BaseColumns, Parcelable {
 
@@ -41,7 +40,7 @@ public class NotificationEntity implements BaseColumns, Parcelable {
 
     private static final long MAX_NOTIFICATION_TIME_TO_LIVE = DateUtils.DAY_IN_MILLIS * 15L;
 
-    public static final Uri CONTENT_URI = Uri.parse("content://" + AUTHORITY + "/" + TABLE_NAME);
+    public static final Uri CONTENT_URI = Uri.parse("content://" + BuildConfig.APPLICATION_ID + "/" + TABLE_NAME);
 
     static final String GROUP_ID = "group_id";
     static final String ACCOUNT_ID = "account_id";

--- a/app/src/main/java/com/ruesga/rview/providers/RviewProvider.java
+++ b/app/src/main/java/com/ruesga/rview/providers/RviewProvider.java
@@ -30,6 +30,8 @@ import android.net.Uri;
 import android.text.TextUtils;
 import android.util.Log;
 
+import com.ruesga.rview.BuildConfig;
+
 import java.util.ArrayList;
 
 import androidx.annotation.NonNull;
@@ -40,7 +42,7 @@ public class RviewProvider extends ContentProvider {
 
     private static final boolean DEBUG = false;
 
-    public static final String AUTHORITY = "com.ruesga.rview";
+    public static final String AUTHORITY = BuildConfig.APPLICATION_ID;
 
     private DatabaseHelper mOpenHelper;
 

--- a/app/src/main/java/com/ruesga/rview/receivers/CacheCleanerReceiver.java
+++ b/app/src/main/java/com/ruesga/rview/receivers/CacheCleanerReceiver.java
@@ -23,6 +23,7 @@ import android.content.Intent;
 import android.text.format.DateUtils;
 import android.util.Log;
 
+import com.ruesga.rview.BuildConfig;
 import com.ruesga.rview.misc.CacheHelper;
 
 import java.io.File;
@@ -32,7 +33,7 @@ public class CacheCleanerReceiver extends BroadcastReceiver {
 
     private static final String TAG = "CacheCleanerReceiver";
 
-    public static final String ACTION_CLEAN_CACHE = "com.ruesga.rview.action.CLEAN_CACHE";
+    public static final String ACTION_CLEAN_CACHE = BuildConfig.APPLICATION_ID + ".action.CLEAN_CACHE";
 
     @Override
     public void onReceive(Context context, Intent intent) {

--- a/app/src/main/java/com/ruesga/rview/receivers/NotificationReceiver.java
+++ b/app/src/main/java/com/ruesga/rview/receivers/NotificationReceiver.java
@@ -22,6 +22,7 @@ import android.os.Bundle;
 import android.util.Log;
 import android.widget.Toast;
 
+import com.ruesga.rview.BuildConfig;
 import com.ruesga.rview.R;
 import com.ruesga.rview.gerrit.GerritApi;
 import com.ruesga.rview.gerrit.model.DraftActionType;
@@ -46,9 +47,9 @@ public class NotificationReceiver extends BroadcastReceiver {
     private static final String TAG = "NotificationReceiver";
 
     public static final String ACTION_NOTIFICATION_DISMISSED
-            = "com.ruesga.rview.action.NOTIFICATION_DISMISSED";
+            = BuildConfig.APPLICATION_ID + ".action.NOTIFICATION_DISMISSED";
     public static final String ACTION_NOTIFICATION_REPLY
-            = "com.ruesga.rview.action.NOTIFICATION_REPLY";
+            = BuildConfig.APPLICATION_ID + ".action.NOTIFICATION_REPLY";
 
     @Override
     @SuppressWarnings("IfCanBeSwitch")

--- a/app/src/main/java/com/ruesga/rview/services/AccountStatusFetcherService.java
+++ b/app/src/main/java/com/ruesga/rview/services/AccountStatusFetcherService.java
@@ -20,6 +20,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.util.Log;
 
+import com.ruesga.rview.BuildConfig;
 import com.ruesga.rview.gerrit.GerritApi;
 import com.ruesga.rview.gerrit.model.Features;
 import com.ruesga.rview.misc.ExceptionHelper;
@@ -36,7 +37,7 @@ public class AccountStatusFetcherService extends IntentService {
     private static final String TAG = "AccountStatusFetcher";
 
     public static final String ACCOUNT_STATUS_FETCHER_ACTION =
-            "com.ruesga.rview.actions.ACCOUNT_STATUS_FETCHER";
+            BuildConfig.APPLICATION_ID + ".actions.ACCOUNT_STATUS_FETCHER";
     public static final String EXTRA_ACCOUNT = "account";
 
     public AccountStatusFetcherService() {

--- a/app/src/main/java/com/ruesga/rview/services/DeviceRegistrationService.java
+++ b/app/src/main/java/com/ruesga/rview/services/DeviceRegistrationService.java
@@ -21,6 +21,7 @@ import android.content.Intent;
 import android.util.Log;
 
 import com.google.firebase.iid.FirebaseInstanceId;
+import com.ruesga.rview.BuildConfig;
 import com.ruesga.rview.gerrit.GerritApi;
 import com.ruesga.rview.gerrit.model.CloudNotificationInput;
 import com.ruesga.rview.gerrit.model.CloudNotificationResponseMode;
@@ -40,7 +41,7 @@ public class DeviceRegistrationService extends JobIntentService {
 
     private static final String TAG = "DeviceRegisterService";
 
-    public static final String REGISTER_DEVICE_ACTION = "com.ruesga.rview.actions.REGISTER_DEVICE";
+    public static final String REGISTER_DEVICE_ACTION = BuildConfig.APPLICATION_ID + ".actions.REGISTER_DEVICE";
     public static final String EXTRA_ACCOUNT = "account";
 
     private static final String TOKEN_SCOPE = "FCM";


### PR DESCRIPTION
Before submitting #102 I wanted to run the debug build of the app on my device to compare the behaviour. In order to be able to have the debug build coexist to the normal/official build of the app these changes were necessary.

This would enable debug builds (signed with a debug key) to coexist to the official app (signed with the release key).

It's ok if you don't want to merge it, i just put it here in case someone else runs into the same situation.