### PR TITLE
[WIP] styles: Switch AppTheme to MaterialComponents

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -15,7 +15,7 @@
      limitations under the License.
  -->
 <resources>
-    <style name="AppThemeBase" parent="Theme.AppCompat.Light.NoActionBar">
+    <style name="AppThemeBase" parent="Theme.MaterialComponents.Light.NoActionBar.Bridge">
         <item name="colorPrimary">@color/primary</item>
         <item name="colorPrimaryDark">@color/primaryDark</item>
         <item name="colorAccent">@color/accent</item>


### PR DESCRIPTION
Fixes a crash when opening the "About" page.

The dependency "AboutLibraries" contains a layout named [listheader_opensource.xml](https://github.com/mikepenz/AboutLibraries/blob/302e202166173fb14d1d15eec5f1621d094cefdc/library/src/main/res/layout/listheader_opensource.xml#L48-L84), which contains references to com.google.android.material.button.MaterialButton.
That one in turn requires the base app theme to be a descendant of `Theme.MaterialComponents`:

```
android.view.InflateException: Binary XML file line #48 in \
  com.ruesga.rview.debug:layout/listheader_opensource: \
  Binary XML file line #48 in com.ruesga.rview.debug:layout/listheader_opensource: \
  Error inflating class com.google.android.material.button.MaterialButton
Caused by: java.lang.IllegalArgumentException: \
  The style on this component requires your app theme to be \
  Theme.MaterialComponents (or a descendant).
```

@jruesga This is quite ugly, do you think only styling the AboutLibraries fragment could work instead? They suggest using something akin to defining a `CustomAboutLibrariesStyle` with `parent="Theme.MaterialComponents.Light.NoActionBar", see the [README](https://github.com/mikepenz/AboutLibraries/blob/302e202166173fb14d1d15eec5f1621d094cefdc/README.md#style-the-aboutlibraries-%EF%B8%8F)

---

Btw, still haven't forgotten about the [F-Droid submission](https://github.com/jruesga/rview/issues/101), got a lot on my plate though ;)