### PR TITLE
gradle-wrapper: Add distributionSha256Sum

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionSha256Sum=0f316a67b971b7b571dac7215dcf2591a30994b3450e0629925ffcfe2c68cc5c
 distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Suggested by https://gitlab.com/fdroid/fdroiddata/-/merge_requests/7538#note_492682193

Generated by:
```
./gradlew wrapper --gradle-version 6.3 \
    --distribution-type all \
    --gradle-distribution-sha256-sum 0f316a67b971b7b571dac7215dcf2591a30994b3450e0629925ffcfe2c68cc5c
```

Corresponds to https://gradle.org/release-checksums/
> Binary-only (-bin) ZIP Checksum: 038794feef1f4745c6347107b6726279d1c824f3fc634b60f86ace1e9fbd1768
> Complete (-all) ZIP Checksum: 0f316a67b971b7b571dac7215dcf2591a30994b3450e0629925ffcfe2c68cc5c
> Wrapper JAR Checksum: 1cef53de8dc192036e7b0cc47584449b0cf570a00d560bfaa6c9eabe06e1fc06

<strike>Note that this replaces the `-all` variant with the `-bin` variant (only `-bin` has sha265sums published it seems). Hope this is ok.</strike> _Continuing to use the `-all` variant now._